### PR TITLE
Wait for indexing in writer

### DIFF
--- a/node-tests/writer-test.js
+++ b/node-tests/writer-test.js
@@ -98,8 +98,6 @@ describe('identitymind/writer', function() {
       }
     });
 
-    await env.lookup('hub:indexers').update({ realTime: true });
-
     let user = (await searcher.get(env.session, 'master', 'users', 'create-only')).data;
 
     expect(user.attributes['kyc-transaction']).to.equal("92514582");


### PR DESCRIPTION
This is so that requests to update the user after creating an IM verification are instantly up-to-date.

The kyc form instantly refreshes the user model after creating the IM verification, however if we don't wait for reindexing, the user model might still not have the correct IM verification id in the json, causing the UI to go out of syunc