### PR TITLE
add date format placeholder for browsers that don't have date picker

### DIFF
--- a/addon/templates/components/text-input.hbs
+++ b/addon/templates/components/text-input.hbs
@@ -11,7 +11,7 @@
     {{/each-in}}
   </select>
 {{else}}
-  {{input type=info.type value=value class='modal-input' name=field id=(concat "kyc-field_" field) disabled=isDisabled}}
+  {{input type=info.type value=value class='modal-input' name=field id=(concat "kyc-field_" field) disabled=isDisabled placeholder=(if (eq info.type 'date') "mm/dd/yyyy")}}
 {{/if}}
 {{#if showErrorMessage}}
   <div class='field-error'>


### PR DESCRIPTION
displays "mm/dd/yyyy" placeholder for date of birth field on browsers such as safari that don't support date type